### PR TITLE
run.sh: Listen anywhere if SOTA_CLIENT_ADDR is not set

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -9,8 +9,8 @@ export DBUS_SESSION_BUS_ADDRESS
 export DBUS_SESSION_BUS_PID
 
 LOGLEVEL=${LOGLEVEL:-"info"}
-SOTA_CLIENT="${SOTA_CLIENT_ADDR:-sota-client}:${SOTA_CLIENT_PORT:-9080}"
+SOTA_CLIENT="${SOTA_CLIENT_ADDR:-0.0.0.0}:${SOTA_CLIENT_PORT:-9080}"
 RVI="${RVI:-http://rvi-client:8901}"
 
 export RUST_LOG=${RUST_LOG:-"sota_client=$LOGLEVEL"}
-/bin/sota_client -c /var/sota/client.toml -r "$RVI" -e "$SOTA_CLIENT"
+/usr/bin/sota_client -c /var/sota/client.toml -r "$RVI" -e "$SOTA_CLIENT"


### PR DESCRIPTION
Force sota_client to listen anywhere instead of
on the possibly unknown host sota-client if
SOTA_CLIENT_ADDR is not set.

Signed-off-by: Leon Anavi leon.anavi@konsulko.com
